### PR TITLE
Add gemspec metadata

### DIFF
--- a/turso_libsql.gemspec
+++ b/turso_libsql.gemspec
@@ -14,7 +14,10 @@ Gem::Specification.new do |s|
   s.homepage = 'https://rubygems.org/gems/turso_libsql'
   s.license = 'MIT'
   s.required_ruby_version = '>= 3.3'
-
+  s.metadata = {
+    'bug_tracker_uri' => 'https://github.com/tursodatabase/libsql-ruby/issues',
+    'source_code_uri' => 'https://github.com/tursodatabase/libsql-ruby'
+  }
   s.add_runtime_dependency 'ffi', '~> 1.17'
   s.add_development_dependency 'rspec', '~> 3.10'
 end


### PR DESCRIPTION
This adds some metadata to the gemspec. Rubygems will pick this up and show "Source Code" and "Bug Tracker" links on the gem page. Other links can be added, as detailed here:

https://guides.rubygems.org/specification-reference/#metadata
