### PR TITLE
Fix faulty logic in Connection#transaction

### DIFF
--- a/lib/libsql.rb
+++ b/lib/libsql.rb
@@ -504,7 +504,7 @@ module Libsql
         abort = true
         raise
       ensure
-        abort and tx.rollback or tx.commit
+        abort ? tx.rollback : tx.commit
       end
     end
 

--- a/spec/libsql_spec.rb
+++ b/spec/libsql_spec.rb
@@ -73,4 +73,16 @@ RSpec.describe do
       expect(count).to eq(0)
     end
   end
+
+  describe 'Connection#transaction' do
+    context 'when there is an exception' do
+      it 'aborts the transaction and raises the exception' do
+        exception_class = Class.new(StandardError)
+
+        db.connect do |conn|
+          expect { conn.transaction { raise exception_class } }.to raise_error(exception_class)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes a logic error in the Connection#transaction ensure block.

Transaction#rollback returns `nil`, so with the current logic Transaction#commit will also be called and that will raise `ClosedException` instead of the exception that was originally raised.