### PR TITLE
feat: support providing namespace during database init

### DIFF
--- a/lib/libsql.rb
+++ b/lib/libsql.rb
@@ -129,7 +129,8 @@ module CLibsql # :nodoc:
            disable_read_your_writes: :bool,
            webpki: :bool,
            synced: :bool,
-           disable_safety_assert: :bool
+           disable_safety_assert: :bool,
+           namespace: :pointer
   end
 
   class Bind < FFI::Struct # :nodoc:
@@ -548,7 +549,7 @@ module Libsql
     def initialize(options = {})
       desc = CLibsql::DatabaseDesc.new
 
-      %i[path url auth_token encryption_key].each do |sym|
+      %i[path url auth_token encryption_key namespace].each do |sym|
         desc[sym] = FFI::MemoryPointer.from_string options[sym] unless options[sym].nil?
       end
 


### PR DESCRIPTION
* depends on https://github.com/tursodatabase/libsql-c/pull/24

Adds support for passing a namespace to the database init, supporting changes introduced in https://github.com/tursodatabase/libsql/commit/96e57c2e99c70ebdb4ae8cc1845fd827cd26f130.

running a modified `examples/remote.rb`:

```
└‹$› irb test.rb
test.rb(main):001> require_relative 'lib/libsql'
=> true
test.rb(main):002> 
test.rb(main):003> args = {
test.rb(main):004*     url: "http://127.0.0.1:6667",
test.rb(main):005*     auth_token: "testing",
test.rb(main):006*     namespace: "testing",
test.rb(main):007*   }.compact
=> {:url=>"http://127.0.0.1:6667", :auth_token=>"testing", :namespace=>"testing"}
test.rb(main):008> 
test.rb(main):009> db = Libsql::Database.new(**args)
=> 
#<Libsql::Database:0x0000000104e1a528 @inner=#<CLibsql::Database:0x0000000104e19...
test.rb(main):010> 
test.rb(main):011> db.connect do |conn|
test.rb(main):012*     conn.execute_batch <<-SQL
test.rb(main):013"     CREATE TABLE IF NOT EXISTS users (email TEXT);
test.rb(main):014"     INSERT INTO users VALUES ('first@example.com');
test.rb(main):015"     INSERT INTO users VALUES ('second@example.com');
test.rb(main):016"     INSERT INTO users VALUES ('third@example.com');
test.rb(main):017"   SQL
test.rb(main):018*   
test.rb(main):019*     rows = conn.query 'SELECT * FROM users'
test.rb(main):020*     print "Users: #{rows.to_a}\n"
test.rb(main):021*     rows.close
test.rb(main):022*   end
Users: [{"email"=>"first@example.com"}, {"email"=>"second@example.com"}, {"email"=>"third@example.com"}]
=> nil
test.rb(main):023> 
```

verifying the database table content from the running sqld:

![image](https://github.com/user-attachments/assets/e6297f25-f29b-4cf4-980a-8fc12b5bdf07)
